### PR TITLE
Add light/dark mode toggle with localStorage persistence

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,6 +14,16 @@ export default function App() {
   const [activeAccount, setActiveAccount] = useState(null)
   const [page, setPage] = useState('connect') // connect | dashboard | scan | compare | relations | events
   const [loading, setLoading] = useState(true)
+  const [theme, setTheme] = useState(() => localStorage.getItem('theme') || 'dark')
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme)
+    localStorage.setItem('theme', theme)
+  }, [theme])
+
+  function toggleTheme() {
+    setTheme(t => t === 'dark' ? 'light' : 'dark')
+  }
 
   useEffect(() => {
     loadAccounts()
@@ -77,6 +87,8 @@ export default function App() {
         onAddAccount={() => setPage('connect')}
         onSwitchAccount={switchAccount}
         onRemoveAccount={removeAccount}
+        theme={theme}
+        onToggleTheme={toggleTheme}
       />
       <main className={styles.main}>
         {page === 'connect' && <ConnectPage onAdd={addAccount} />}

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -10,7 +10,7 @@ const NAV = [
   { id: 'events',     label: 'Events',      icon: ActivityIcon },
 ]
 
-export default function Sidebar({ accounts, activeAccount, activePage, onNavigate, onAddAccount, onSwitchAccount, onRemoveAccount }) {
+export default function Sidebar({ accounts, activeAccount, activePage, onNavigate, onAddAccount, onSwitchAccount, onRemoveAccount, theme, onToggleTheme }) {
   const [showAccMenu, setShowAccMenu] = useState(false)
 
   return (
@@ -92,6 +92,9 @@ export default function Sidebar({ accounts, activeAccount, activePage, onNavigat
           <LockIcon />
           <span>All data stored locally</span>
         </div>
+        <button className={s.themeToggle} onClick={onToggleTheme} title={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}>
+          {theme === 'dark' ? <SunIcon /> : <MoonIcon />}
+        </button>
       </div>
     </aside>
   )
@@ -112,3 +115,5 @@ function PeopleIcon() { return <svg width="16" height="16" viewBox="0 0 24 24" f
 function ActivityIcon() { return <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg> }
 function ChevronIcon({ className }) { return <svg className={className} width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><polyline points="6 9 12 15 18 9"/></svg> }
 function LockIcon() { return <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0110 0v4"/></svg> }
+function SunIcon() { return <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg> }
+function MoonIcon() { return <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/></svg> }

--- a/src/components/Sidebar.module.css
+++ b/src/components/Sidebar.module.css
@@ -154,8 +154,23 @@
 .footer {
   padding: 12px 16px;
   border-top: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 }
 .footerNote {
   display: flex; align-items: center; gap: 6px;
   font-size: 10px; color: var(--text3); font-family: 'DM Mono', monospace;
 }
+.themeToggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px; height: 26px;
+  border-radius: var(--rs);
+  border: 1px solid var(--border2);
+  background: transparent;
+  color: var(--text3);
+  transition: background .15s, color .15s, border-color .15s;
+}
+.themeToggle:hover { background: var(--bg3); color: var(--text2); border-color: var(--border3); }

--- a/src/index.css
+++ b/src/index.css
@@ -39,6 +39,27 @@
   --font-mono:    'DM Mono', monospace;
 }
 
+[data-theme="light"] {
+  --bg:       #f5f5f8;
+  --bg2:      #ededf2;
+  --bg3:      #e4e4eb;
+  --bg4:      #d8d8e2;
+  --bg5:      #ccccd8;
+  --border:   rgba(0,0,0,0.07);
+  --border2:  rgba(0,0,0,0.12);
+  --border3:  rgba(0,0,0,0.22);
+  --text:     #111118;
+  --text2:    #505060;
+  --text3:    #909099;
+  --pink-dim: rgba(232,64,128,0.08);
+  --pink-glow:rgba(232,64,128,0.14);
+  --green-dim:rgba(40,180,100,0.1);
+  --red-dim:  rgba(220,60,44,0.1);
+  --gold-dim: rgba(210,148,20,0.1);
+  --blue-dim: rgba(50,130,240,0.1);
+  --purple-dim:rgba(130,90,220,0.1);
+}
+
 html, body, #root {
   height: 100%;
   background: var(--bg);


### PR DESCRIPTION
- Adds [data-theme="light"] CSS variables to index.css for full light theme support
- Manages theme state in App.jsx, persists to localStorage, applies via data-theme on documentElement
- Adds sun/moon toggle button in Sidebar footer
- Keeps accent colors consistent across themes, adjusts dim variants for readability