### PR TITLE
Show DB error banner on ConnectPage when database fails to initialise

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,6 +15,7 @@ export default function App() {
   const [activeAccount, setActiveAccount] = useState(null)
   const [page, setPage] = useState('connect') // connect | dashboard | scan | compare | relations | events
   const [loading, setLoading] = useState(true)
+  const [dbError, setDbError] = useState(false)
   const [theme, setTheme] = useState(() => localStorage.getItem('theme') || 'dark')
 
   useEffect(() => {
@@ -40,6 +41,7 @@ export default function App() {
       }
     } catch (e) {
       console.error('Failed to load accounts:', e)
+      setDbError(true)
     } finally {
       setLoading(false)
     }
@@ -91,7 +93,7 @@ export default function App() {
         logoUrl={logoUrl}
       />
       <main className={styles.main}>
-        {page === 'connect' && <ConnectPage onAdd={addAccount} />}
+        {page === 'connect' && <ConnectPage onAdd={addAccount} dbError={dbError} />}
         {page === 'dashboard' && activeAccount && <DashboardPage {...pageProps} />}
         {page === 'scan' && activeAccount && <ScanPage {...pageProps} />}
         {page === 'compare' && activeAccount && <ComparePage {...pageProps} />}

--- a/src/pages/ConnectPage.jsx
+++ b/src/pages/ConnectPage.jsx
@@ -2,7 +2,7 @@
 import { useState } from 'react'
 import s from './ConnectPage.module.css'
 
-export default function ConnectPage({ onAdd }) {
+export default function ConnectPage({ onAdd, dbError }) {
   const [username, setUsername] = useState('')
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
@@ -24,6 +24,20 @@ export default function ConnectPage({ onAdd }) {
   return (
     <div className={s.page}>
       <div className={s.wrap}>
+
+        {dbError && (
+          <div className={s.dbErrorBanner}>
+            <div className={s.dbErrorIcon}><AlertIcon /></div>
+            <div>
+              <div className={s.dbErrorTitle}>Database unavailable</div>
+              <div className={s.dbErrorBody}>
+                IGTracker could not initialise its local database. Your data cannot be saved until this is resolved.
+                Try <strong>restarting the app</strong>. If the problem persists, reinstall the application.
+              </div>
+            </div>
+          </div>
+        )}
+
         <div className={s.hero}>
           <div className={s.heroIcon}>
             <svg width="28" height="28" viewBox="0 0 24 24" fill="white">
@@ -55,7 +69,8 @@ export default function ConnectPage({ onAdd }) {
           <button
             className={s.btn}
             onClick={handleConnect}
-            disabled={loading}
+            disabled={loading || dbError}
+            title={dbError ? 'Database unavailable — restart the app' : undefined}
           >
             {loading ? 'Adding...' : 'Add account →'}
           </button>
@@ -92,4 +107,7 @@ export default function ConnectPage({ onAdd }) {
 
 function ShieldIcon() {
   return <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" style={{flexShrink:0}}><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+}
+function AlertIcon() {
+  return <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" style={{flexShrink:0}}><path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
 }

--- a/src/pages/ConnectPage.module.css
+++ b/src/pages/ConnectPage.module.css
@@ -63,6 +63,32 @@
 .stepTitle { font-size: 13px; font-weight: 600; margin-bottom: 2px; }
 .stepDesc { font-size: 12px; color: var(--text2); line-height: 1.5; }
 
+.dbErrorBanner {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  background: var(--red-dim);
+  border: 1px solid var(--red);
+  border-radius: var(--r);
+  padding: 14px 16px;
+  margin-bottom: 24px;
+  color: var(--red);
+}
+.dbErrorIcon { margin-top: 1px; }
+.dbErrorTitle {
+  font-size: 13px;
+  font-weight: 700;
+  margin-bottom: 4px;
+  font-family: var(--font-ui);
+}
+.dbErrorBody {
+  font-size: 12px;
+  line-height: 1.6;
+  color: var(--text2);
+  font-family: var(--font-ui);
+}
+.dbErrorBody strong { color: var(--text); font-weight: 600; }
+
 .privacyNote {
   display: flex; align-items: flex-start; gap: 9px;
   font-size: 11px; color: var(--text3); line-height: 1.6;


### PR DESCRIPTION
## Summary

When the database fails to initialise, the app previously landed silently on `ConnectPage` with no indication anything was wrong. Users would try to add an account, receive a cryptic IPC error, and have no idea why.

## Changes

- **`App.jsx`** — added `dbError` state, set to `true` when `loadAccounts()` catches an error from the IPC layer, passed down to `ConnectPage`
- **`ConnectPage.jsx`** — accepts `dbError` prop; renders a prominent red banner above the form when `true`, and disables the "Add account" button with a tooltip
- **`ConnectPage.module.css`** — styles for the error banner using existing `--red` / `--red-dim` design tokens

## Behaviour

| Scenario | Before | After |
|---|---|---|
| DB fails to init | Silent landing on ConnectPage, button appears clickable | Red banner shown, button disabled with tooltip |
| DB healthy | No change | No change |

## Test plan

- [ ] Simulate a DB failure (e.g. corrupt/missing wasm) and confirm the banner appears on launch
- [ ] Confirm the "Add account" button is disabled and shows the tooltip when the banner is visible
- [ ] Confirm normal launches show no banner and the form works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)